### PR TITLE
fix(docker): add Redis dependency to service health checks

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -113,6 +113,8 @@ services:
     depends_on:
       mariadb:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     networks:
       - backend-network
     restart: always    

--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -114,6 +114,8 @@ services:
     depends_on:
       mariadb:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     networks:
       - backend-network
     restart: always    


### PR DESCRIPTION
- Add Redis to service health check dependencies in dev and prod configs
- Ensure services wait for Redis to be ready before startup