### PR TITLE
chore(nginx): upgrade base image to 1.31.0 (CVE-2026-42945)

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.29.1
+FROM nginx:1.31.0
 
 # Install required tools: logrotate for log management, cron for scheduling, curl for downloading gomplate, gomplate for template processing, apache2-utils for htpasswd
 RUN apt-get update && apt-get install -y logrotate cron curl procps apache2-utils \


### PR DESCRIPTION
- Security patch for nginx vulnerability