### PR TITLE
chore: upgrade Python and multiple service dependencies

### DIFF
--- a/alloy/config.river
+++ b/alloy/config.river
@@ -100,9 +100,6 @@ loki.write "default" {
 		tenant_id          = "default"
 		batch_size    	   = "102KiB"
 		batch_wait         = "3s"
-		queue_config {
-			capacity       = "100MiB"
-		}
 	}
 	external_labels = {}
 }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
-# Use Python 3.11 as the base image
-FROM python:3.11
+# Use Python 3.14 as the base image
+FROM python:3.14
 
 # Set working directory
 WORKDIR /app

--- a/backend/api/debug/controller.py
+++ b/backend/api/debug/controller.py
@@ -1,5 +1,6 @@
 import logging
 from fastapi_limiter.depends import RateLimiter
+from pyrate_limiter import Duration, Limiter, Rate
 from utils.response import parse_responses, APIResponse
 from .services import get_ip_debug_info, clear_blocked_ips
 from .schema import IPDebugResponse, ClearBlockedIPsResponse
@@ -18,7 +19,7 @@ router = APIRouter(tags=["Debug"])
                 429: ("Too Many Requests", None),
                 500: ("Internal Server Error", None),
             }),
-            dependencies=[Depends(RateLimiter(times=10, seconds=60))]
+            dependencies=[Depends(RateLimiter(limiter=Limiter(Rate(10, Duration.SECOND * 60))))]
 )
 async def test_ip_detection(request: Request):
     try:

--- a/backend/core/security.py
+++ b/backend/core/security.py
@@ -9,21 +9,23 @@ from core.dependencies import get_db
 from sqlalchemy import update, select
 from typing import Optional, Dict, Any
 from datetime import datetime, timedelta
-from passlib.context import CryptContext
+import bcrypt
 from models.user_sessions import UserSessions
 from sqlalchemy.ext.asyncio import AsyncSession
 from utils.custom_exception import ServerException
 from fastapi import HTTPException, status, Depends
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 logger = logging.getLogger(__name__)
 
 async def hash_password(password: str) -> str:
-    return pwd_context.hash(password)
+    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
 
 async def verify_password(plain_password: str, hashed_password: str) -> bool:
-    return pwd_context.verify(plain_password, hashed_password)
+    return bcrypt.checkpw(
+        plain_password.encode("utf-8"),
+        hashed_password.encode("utf-8"),
+    )
 
 async def create_access_token(data: Dict[str, Any]) -> str:
     to_encode = data.copy()

--- a/backend/logging_config.yaml
+++ b/backend/logging_config.yaml
@@ -41,10 +41,6 @@ loggers:
     handlers: []
     level: INFO
     propagate: no
-  passlib:
-    handlers: [console]
-    level: WARNING
-    propagate: no
   apscheduler:
     handlers: [console]
     level: WARNING

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,9 +2,8 @@ from core.config import settings, setup_logging
 setup_logging("logging_config.yaml")
 from api import api_router
 from fastapi import FastAPI
-from core.redis import init_redis, get_redis
+from core.redis import init_redis
 from core.database import init_db
-from fastapi_limiter import FastAPILimiter
 from contextlib import asynccontextmanager
 from extensions import register_extensions
 from middleware import register_middlewares
@@ -17,7 +16,6 @@ async def lifespan(app: FastAPI):
     register_schedules()
     scheduler.start()
     await init_redis()
-    await FastAPILimiter.init(get_redis())
     yield
     scheduler.shutdown()
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,41 +1,40 @@
 # Web framework & server
-fastapi[all]==0.116.0
-uvicorn==0.35.0
-gunicorn==23.0.0
+fastapi[all]==0.139.1
+uvicorn==0.51.0
+gunicorn==26.0.0
 asgi-lifespan==2.1.0
-fastapi-limiter==0.1.6
+fastapi-limiter==0.2.0
 
 # Database & ORM
-sqlalchemy[asyncio]==2.0.41
-alembic==1.16.2
-uuid-utils==0.12.0
+sqlalchemy[asyncio]==2.0.51
+alembic==1.18.5
+uuid-utils==0.17.0
 
 # Async drivers
-aiomysql==0.2.0
-pymysql==1.1.1
+aiomysql==0.3.2
+pymysql==1.2.0
 
 # Config & env
-python-dotenv==1.1.1
-pydantic==2.11.7
-pydantic-settings==2.10.1
+python-dotenv==1.2.2
+pydantic==2.13.4
+pydantic-settings==2.14.2
 
 # Security & auth
 python-jose==3.5.0
-passlib==1.7.4
-bcrypt==4.0.1
+bcrypt==5.0.0
 
 # HTTP client
-requests==2.32.4
-httpx==0.27.2
+requests==2.34.2
+httpx==0.28.1
 
 # Testing
-pytest==8.4.1
-pytest-asyncio==1.0.0
-coverage==7.9.2
-pytest-cov==6.2.1
+pytest==9.1.1
+pytest-asyncio==1.4.0
+coverage==7.15.2
+pytest-cov==7.1.0
 
 # Scheduler/Task
-apscheduler==3.11.0
+apscheduler==3.11.3
 
 # Redis
-redis==6.2.0
+redis==8.0.1

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,7 +1,6 @@
 import pytest
 import asyncio
 import pytest_asyncio
-import fastapi_limiter
 from uuid_utils import uuid7
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, patch
@@ -25,21 +24,6 @@ from models.role_mapper import RoleMapper
 
 mock_redis = AsyncMock()
 mock_redis.evalsha.return_value = 1000  # Indicates 1000ms remaining
-
-
-async def fake_http_callback(request, response, pexpire):
-    return
-
-
-async def fake_identifier(request):
-    return "test"
-
-
-fastapi_limiter.FastAPILimiter.redis = mock_redis
-fastapi_limiter.FastAPILimiter.prefix = "fastapi-limiter"
-fastapi_limiter.FastAPILimiter.lua_sha = "dummy_sha"
-fastapi_limiter.FastAPILimiter.identifier = fake_identifier
-fastapi_limiter.FastAPILimiter.http_callback = fake_http_callback
 
 
 @pytest_asyncio.fixture(scope="function")

--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -143,7 +143,7 @@ services:
       retries: 5
 
   mariadb:
-    image: mariadb:11.3
+    image: mariadb:12.3.2
     environment:
       - TZ=${TIMEZONE}
       - MYSQL_DATABASE=${DB_DATABASE}
@@ -165,7 +165,7 @@ services:
       retries: 5
       
   phpmyadmin:
-    image: phpmyadmin/phpmyadmin:5.2.2
+    image: phpmyadmin/phpmyadmin:5.2.3
     environment:
       - TZ=${TIMEZONE}
       - PMA_HOST=mariadb
@@ -181,7 +181,7 @@ services:
     restart: always
 
   redis:
-    image: redis:8.6.3
+    image: redis:8.6.4
     environment:
       - TZ=${TIMEZONE}
       - REDIS_PASSWORD=${REDIS_PASSWORD}
@@ -205,7 +205,7 @@ services:
       retries: 5
 
   redis-insight:
-    image: redis/redisinsight:2.70
+    image: redis/redisinsight:2.70.1
     environment:
       - TZ=${TIMEZONE}
       - RI_REDIS_HOST=redis
@@ -229,7 +229,7 @@ services:
       retries: 5
 
   loki:
-    image: grafana/loki:3.5.3
+    image: grafana/loki:3.7.3
     environment:
       - TZ=${TIMEZONE}
     volumes:
@@ -252,7 +252,7 @@ services:
           memory: 2G
 
   alloy:
-    image: grafana/alloy:v1.10.0
+    image: grafana/alloy:v1.17.1
     environment:
       - TZ=${TIMEZONE}
     volumes:
@@ -268,7 +268,7 @@ services:
       - loki
 
   grafana:
-    image: grafana/grafana:12.2.0-16557133545
+    image: grafana/grafana:12.2.10
     environment:
       - TZ=${TIMEZONE}
       - SSL_ENABLE=${SSL_ENABLE}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -142,7 +142,7 @@ services:
       retries: 5
 
   mariadb:
-    image: mariadb:11.3
+    image: mariadb:11.8.8
     environment:
       - TZ=${TIMEZONE:-UTC}
       - MYSQL_DATABASE=${DB_DATABASE:-app}
@@ -164,7 +164,7 @@ services:
       retries: 5
       
   phpmyadmin:
-    image: phpmyadmin/phpmyadmin:5.2.2
+    image: phpmyadmin/phpmyadmin:5.2.3
     environment:
       - TZ=${TIMEZONE:-UTC}
       - PMA_HOST=mariadb
@@ -180,7 +180,7 @@ services:
     restart: always
 
   redis:
-    image: redis:8.6.3
+    image: redis:8.6.4
     environment:
       - TZ=${TIMEZONE:-UTC}
       - REDIS_PASSWORD=${REDIS_PASSWORD:-redis}
@@ -204,7 +204,7 @@ services:
       retries: 5
 
   redis-insight:
-    image: redis/redisinsight:2.70
+    image: redis/redisinsight:2.70.1
     environment:
       - TZ=${TIMEZONE:-UTC}
       - RI_REDIS_HOST=redis
@@ -228,7 +228,7 @@ services:
       retries: 5
 
   loki:
-    image: grafana/loki:3.5.3
+    image: grafana/loki:3.7.3
     environment:
       - TZ=${TIMEZONE:-UTC}
     volumes:
@@ -251,7 +251,7 @@ services:
           memory: 2G
 
   alloy:
-    image: grafana/alloy:v1.10.0
+    image: grafana/alloy:v1.17.1
     environment:
       - TZ=${TIMEZONE:-UTC}
     volumes:
@@ -267,7 +267,7 @@ services:
       - loki
 
   grafana:
-    image: grafana/grafana:12.2.0-16557133545
+    image: grafana/grafana:12.2.10
     environment:
       - TZ=${TIMEZONE:-UTC}
       - SSL_ENABLE=${SSL_ENABLE:-false}

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.31.0
+FROM nginx:1.31.3
 
 # Install required tools: logrotate for log management, cron for scheduling, curl for downloading gomplate, gomplate for template processing, apache2-utils for htpasswd
 RUN apt-get update && apt-get install -y logrotate cron curl procps apache2-utils \


### PR DESCRIPTION
- Bump Python 3.11 → 3.14 and refresh requirements to latest compatible versions
- Upgrade MariaDB, Redis, Loki, Alloy, Grafana, and Nginx images
- Adapt to fastapi-limiter 0.2 API; replace passlib with bcrypt
- Fix Alloy loki.write queue_config compatibility