### PR TITLE
feat: use OpenAPI examples for multi-case responses

### DIFF
--- a/backend/api/account/controller.py
+++ b/backend/api/account/controller.py
@@ -4,7 +4,7 @@ from core.security import verify_token
 from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi import APIRouter, Depends, HTTPException, Response
 from .schema import UserProfile, UserUpdate, PasswordChange
-from utils.response import APIResponse, parse_responses, common_responses
+from utils.response import APIResponse, parse_responses, common_responses, make_error_examples
 from .services import get_user_by_id, update_user_profile, change_password
 from utils.custom_exception import AuthenticationException, NotFoundException
 from extensions.smtp import get_mailer, SMTPMailer
@@ -110,7 +110,10 @@ async def update_user_profile_api(
     summary="Change current user password",
     responses=parse_responses({
         200: ("Password changed successfully", None),
-        401: ("Invalid or expired token / Current password is incorrect", None)
+        401: ("Unauthorized", None, make_error_examples(401, {
+            "invalidToken": "Invalid or expired token",
+            "incorrectPassword": "Current password is incorrect",
+        })),
     }, common_responses)
 )
 async def change_user_password_api(

--- a/backend/api/auth/controller.py
+++ b/backend/api/auth/controller.py
@@ -8,7 +8,7 @@ from utils.get_real_ip import get_real_ip
 from sqlalchemy.ext.asyncio import AsyncSession
 from core.security import verify_password_reset_token, verify_token, verify_email_verification_token
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, Query
-from utils.response import APIResponse, parse_responses, common_responses
+from utils.response import APIResponse, parse_responses, common_responses, make_error_examples
 from extensions.smtp import get_mailer, SMTPMailer
 from utils.custom_exception import SMTPNotConfiguredException
 from .schema import (
@@ -119,7 +119,7 @@ async def register_api(
     summary="Login account",
     responses=parse_responses({
         200: ("User logged in successfully", UserLoginResponse),
-        202: ("Password reset required / Email verification required", ActionRequiredResponse, action_required_response_examples),
+        202: ("Action required", ActionRequiredResponse, action_required_response_examples),
         401: ("Invalid email or password", None)
     }, common_responses)
 )
@@ -177,7 +177,10 @@ async def login_api(
     summary="Logout account",
     responses=parse_responses({
         200: ("User logged out successfully", None),
-        401: ("Invalid or expired session / Invalid or expired token", None)
+        401: ("Unauthorized", None, make_error_examples(401, {
+            "invalidSession": "Invalid or expired session",
+            "invalidToken": "Invalid or expired token",
+        })),
     }, common_responses)
 )
 async def logout_api(
@@ -224,7 +227,10 @@ async def logout_api(
     summary="Refresh token",
     responses=parse_responses({
         200: ("Token refreshed successfully", TokenResponse),
-        401: ("Invalid or expired session / Invalid or expired CSRF token", None)
+        401: ("Unauthorized", None, make_error_examples(401, {
+            "invalidSession": "Invalid or expired session",
+            "invalidCsrf": "Invalid or expired CSRF token",
+        })),
     }, common_responses)
 )
 async def token_api(

--- a/backend/utils/response.py
+++ b/backend/utils/response.py
@@ -14,20 +14,65 @@ class ValidationErrorData(RootModel[dict[str, str]]):
     """Model for validation error data structure"""
     pass
 
+def is_openapi_examples(example: dict) -> bool:
+    """
+    Detect OpenAPI Media Type ``examples`` (named map with dropdown in Swagger UI).
+
+    Expected shape:
+        {
+          "caseA": {"summary": "...", "value": {...}},
+          "caseB": {"value": {...}},
+        }
+    """
+    if not isinstance(example, dict) or not example:
+        return False
+    if "code" in example or "message" in example or "data" in example:
+        return False
+    return all(
+        isinstance(item, dict) and "value" in item
+        for item in example.values()
+    )
+
+
 def make_response_doc(description: str, model: Optional[Type] = None, example: Optional[dict] = None) -> dict:
-    """Create OpenAPI response documentation with model and example"""
+    """Create OpenAPI response documentation with model and example(s)"""
     doc = {"description": description}
     if model:
         doc["model"] = APIResponse[model]
     if example:
-        doc["content"] = {"application/json": {"example": example}}
+        media = (
+            {"examples": example}
+            if is_openapi_examples(example)
+            else {"example": example}
+        )
+        doc["content"] = {"application/json": media}
     return doc
+
+def make_error_examples(code: int, cases: dict[str, str]) -> dict:
+    """
+    Build OpenAPI named ``examples`` for simple error responses.
+
+    Example:
+        make_error_examples(401, {
+            "invalidSession": "Invalid or expired session",
+            "invalidCsrf": "Invalid or expired CSRF token",
+        })
+    """
+    return {
+        key: {
+            "summary": message,
+            "value": {"code": code, "message": message, "data": None},
+        }
+        for key, message in cases.items()
+    }
+
 
 def parse_responses(custom: dict, default: dict = None) -> dict:
     """
     Parse and merge responses. Supports:
     - 2-tuple: (description, model) - auto-generates example
-    - 3-tuple: (description, model, example) - uses provided example  
+    - 3-tuple: (description, model, example) - single example dict,
+      or OpenAPI named ``examples`` map (Swagger UI dropdown)
     - string: description only - creates simple error response
     """
     # Merge default responses first, then override with custom ones
@@ -55,11 +100,12 @@ def parse_responses(custom: dict, default: dict = None) -> dict:
                 result[code] = make_response_doc(desc, model, example)
             elif len(val) == 3:
                 desc, model, example = val
-                # Auto-fill missing code and message
-                if "code" not in example:
-                    example["code"] = code
-                if "message" not in example:
-                    example["message"] = desc
+                # Auto-fill only for a single response body example
+                if not is_openapi_examples(example):
+                    if "code" not in example:
+                        example["code"] = code
+                    if "message" not in example:
+                        example["message"] = desc
                 result[code] = make_response_doc(desc, model, example)
         elif isinstance(val, str):
             example = {"code": code, "message": val, "data": None}


### PR DESCRIPTION
- add make_error_examples helper in response utils
- replace slash-separated auth and account 401 docs
- clarify login 202 description with existing examples