### PR TITLE
refactor: split Alloy config into modular pipelines

### DIFF
--- a/alloy/destinations.alloy
+++ b/alloy/destinations.alloy
@@ -1,0 +1,24 @@
+loki.write "default" {
+	endpoint {
+		url          = "http://loki:3100/loki/api/v1/push"
+		tenant_id    = "default"
+		batch_size   = "102KiB"
+		batch_wait   = "3s"
+	}
+	external_labels = {}
+}
+
+otelcol.exporter.otlp "tempo" {
+	client {
+		endpoint = "tempo:4317"
+		tls {
+			insecure = true
+		}
+	}
+}
+
+prometheus.remote_write "prometheus" {
+	endpoint {
+		url = "http://prometheus:9090/api/v1/write"
+	}
+}

--- a/alloy/logs_backend.alloy
+++ b/alloy/logs_backend.alloy
@@ -1,9 +1,9 @@
 local.file_match "backend_logs" {
 	path_targets = [{
-		__address__  = "localhost",
-		__path__     = "/var/log/backend/*.log*",
-		job          = "backend_logs",
-		service = "backend_logs",
+		__address__ = "localhost",
+		__path__    = "/var/log/backend/*.log*",
+		job         = "backend_logs",
+		service     = "backend_logs",
 	}]
 }
 
@@ -15,14 +15,14 @@ loki.process "backend_logs" {
 	}
 
 	stage.timestamp {
-		source = "timestamp"
-		format = "2006-01-02 15:04:05,000"
+		source   = "timestamp"
+		format   = "2006-01-02 15:04:05,000"
 		location = "Asia/Taipei"
 	}
 
 	stage.labels {
 		values = {
-			level = "level",
+			level  = "level",
 			logger = "logger",
 		}
 	}
@@ -32,8 +32,8 @@ loki.process "backend_logs" {
 	}
 	stage.labels {
 		values = {
-			method = "method",
-			path = "path",
+			method     = "method",
+			path       = "path",
 			ip_address = "ip_address",
 		}
 	}
@@ -43,9 +43,9 @@ loki.process "backend_logs" {
 	}
 	stage.labels {
 		values = {
-			method = "method",
-			path = "path",
-			ip_address = "ip_address",
+			method      = "method",
+			path        = "path",
+			ip_address  = "ip_address",
 			status_code = "status_code",
 		}
 	}
@@ -55,9 +55,9 @@ loki.process "backend_logs" {
 	}
 	stage.labels {
 		values = {
-			method = "method",
-			path = "path",
-			ip_address = "ip_address",
+			method      = "method",
+			path        = "path",
+			ip_address  = "ip_address",
 			status_code = "status_code",
 		}
 	}
@@ -103,21 +103,21 @@ loki.process "backend_logs" {
 
 	stage.structured_metadata {
 		values = {
-			level = "level",
-			logger = "logger",
-			timestamp = "timestamp",
-			method = "method",
-			path = "path",
-			ip_address = "ip_address",
-			user_agent = "user_agent",
-			status_code = "status_code",
-			duration = "duration",
-			error_code = "error_code",
-			error_message = "error_message",
-			traceID = "traceID",
-			request_query = "request_query",
-			payload = "payload",
-			data = "data",
+			level          = "level",
+			logger         = "logger",
+			timestamp      = "timestamp",
+			method         = "method",
+			path           = "path",
+			ip_address     = "ip_address",
+			user_agent     = "user_agent",
+			status_code    = "status_code",
+			duration       = "duration",
+			error_code     = "error_code",
+			error_message  = "error_message",
+			traceID        = "traceID",
+			request_query  = "request_query",
+			payload        = "payload",
+			data           = "data",
 		}
 	}
 }
@@ -128,62 +128,4 @@ loki.source.file "backend_logs" {
 	legacy_positions_file = "/tmp/positions.yaml"
 	tail_from_end         = false
 	encoding              = "UTF-8"
-}
-
-loki.write "default" {
-	endpoint {
-		url                = "http://loki:3100/loki/api/v1/push"
-		tenant_id          = "default"
-		batch_size    	   = "102KiB"
-		batch_wait         = "3s"
-	}
-	external_labels = {}
-}
-
-otelcol.receiver.otlp "default" {
-	grpc {
-		endpoint = "0.0.0.0:4317"
-	}
-
-	http {
-		endpoint = "0.0.0.0:4318"
-	}
-
-	output {
-		traces = [otelcol.exporter.otlp.tempo.input]
-	}
-}
-
-otelcol.exporter.otlp "tempo" {
-	client {
-		endpoint = "tempo:4317"
-		tls {
-			insecure = true
-		}
-	}
-}
-
-prometheus.scrape "docker_stats" {
-	targets = [{
-		__address__ = "docker-stats-exporter:9100",
-		job         = "docker_stats",
-	}]
-	forward_to      = [prometheus.remote_write.prometheus.receiver]
-	scrape_interval = "15s"
-}
-
-prometheus.scrape "node" {
-	targets = [{
-		__address__ = "172.17.0.1:9100",
-		job         = "node",
-		instance    = "host",
-	}]
-	forward_to      = [prometheus.remote_write.prometheus.receiver]
-	scrape_interval = "15s"
-}
-
-prometheus.remote_write "prometheus" {
-	endpoint {
-		url = "http://prometheus:9090/api/v1/write"
-	}
 }

--- a/alloy/metrics_docker.alloy
+++ b/alloy/metrics_docker.alloy
@@ -1,0 +1,8 @@
+prometheus.scrape "docker_stats" {
+	targets = [{
+		__address__ = "docker-stats-exporter:9100",
+		job         = "docker_stats",
+	}]
+	forward_to      = [prometheus.remote_write.prometheus.receiver]
+	scrape_interval = "15s"
+}

--- a/alloy/metrics_node.alloy
+++ b/alloy/metrics_node.alloy
@@ -1,0 +1,9 @@
+prometheus.scrape "node" {
+	targets = [{
+		__address__ = "172.17.0.1:9100",
+		job         = "node",
+		instance    = "host",
+	}]
+	forward_to      = [prometheus.remote_write.prometheus.receiver]
+	scrape_interval = "15s"
+}

--- a/alloy/traces_otlp.alloy
+++ b/alloy/traces_otlp.alloy
@@ -1,0 +1,13 @@
+otelcol.receiver.otlp "default" {
+	grpc {
+		endpoint = "0.0.0.0:4317"
+	}
+
+	http {
+		endpoint = "0.0.0.0:4318"
+	}
+
+	output {
+		traces = [otelcol.exporter.otlp.tempo.input]
+	}
+}

--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -332,12 +332,10 @@ services:
       - alloy-data:/data
       - ./backend/logs:/var/log/backend
       - ./nginx/logs:/var/log/nginx
-      - ./alloy/config.river:/etc/alloy/config.river
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /sys:/sys:ro
+      - ./alloy:/etc/alloy:ro
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    command: ["run", "--storage.path=/data", "/etc/alloy/config.river"]
+    command: ["run", "--storage.path=/data", "/etc/alloy"]
     networks:
       - backend-network
     restart: always

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -331,12 +331,10 @@ services:
       - alloy-data:/data
       - ./backend/logs:/var/log/backend
       - ./nginx/logs:/var/log/nginx
-      - ./alloy/config.river:/etc/alloy/config.river
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /sys:/sys:ro
+      - ./alloy:/etc/alloy:ro
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    command: ["run", "--storage.path=/data", "/etc/alloy/config.river"]
+    command: ["run", "--storage.path=/data", "/etc/alloy"]
     networks:
       - backend-network
     restart: always

--- a/docker-stats-exporter/exporter.py
+++ b/docker-stats-exporter/exporter.py
@@ -1,8 +1,3 @@
-#!/usr/bin/env python3
-"""Prometheus exporter backed by the Docker Stats API (docker.sock only)."""
-
-from __future__ import annotations
-
 import http.client
 import json
 import socket


### PR DESCRIPTION
- Split monolithic config.river into logs, metrics, traces, and destinations
- Point Compose Alloy service at the alloy config directory
- Drop unused imports from docker-stats-exporter